### PR TITLE
Only compile host ICU tools once for all crosscompilations.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 armeabi
 armeabi-v7a
+cross
 mips
 x86
 arm64-v8a

--- a/build.sh
+++ b/build.sh
@@ -190,12 +190,12 @@ cd $BUILDDIR/$ARCH
 	cp -f $BUILDDIR/config.sub .
 	cp -f $BUILDDIR/config.guess .
 
-	[ -d cross ] || {
-		mkdir cross
-		cd cross
-		../configure || exit 1
+	[ -d $BUILDDIR/cross ] || {
+		mkdir $BUILDDIR/cross
+		cd $BUILDDIR/cross
+		$BUILDDIR/$ARCH/icu/source/configure || exit 1
 		make -j$NCPU VERBOSE=1 || exit 1
-		cd ..
+		cd $BUILDDIR/$ARCH/icu/source
 	} || exit 1
 
 	sed -i,tmp "s@LD_SONAME *=.*@LD_SONAME =@g" config/mh-linux
@@ -216,7 +216,7 @@ cd $BUILDDIR/$ARCH
 		--host=$GCCPREFIX \
 		--prefix=`pwd`/../../ \
 		--with-library-suffix=$LIBSUFFIX \
-		--with-cross-build=`pwd`/cross \
+		--with-cross-build=$BUILDDIR/cross \
 		$libtype \
 		--with-data-packaging=archive \
 		|| exit 1
@@ -367,7 +367,7 @@ cd $BUILDDIR/$ARCH
 		./configure \
 		--host=$GCCPREFIX \
 		--prefix=`pwd`/../../ \
-		--with-cross-build=`pwd`/cross \
+		--with-cross-build=$BUILDDIR/cross \
 		--enable-static --disable-shared \
 		--with-data-packaging=archive \
 		--enable-layoutex \


### PR DESCRIPTION
The host ICU for compiling the target ICU was compile once per
architecture, when it is not necessary to do so.

This change modifies the build script slightly to build the
host ICU once in a common directory which is used by every
architecture.