### PR TITLE
Generate the ICU data into a library.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -218,7 +218,7 @@ cd $BUILDDIR/$ARCH
 		--with-library-suffix=$LIBSUFFIX \
 		--with-cross-build=`pwd`/cross \
 		$libtype \
-		--with-data-packaging=archive \
+		--with-data-packaging=library \
 		|| exit 1
 
 #		ICULEHB_CFLAGS="-I$BUILDDIR/$ARCH/include" \


### PR DESCRIPTION
The archive method will fail for Android installations, unless
the archive data is also moved to the right place, which is not
always possible with Android.

The library method will create a library, which can be copied
almost anywhere inside the app, and loaded from there.

The Swift build system doesn't seem to support moving the data
archive, and it looks like the data should have been in the
library all along, so it also makes sense to have it there.