### PR TITLE
Use PLATFORMVER consistently in the paths.

### DIFF
--- a/setCrossEnvironment-arm64-v8a.sh
+++ b/setCrossEnvironment-arm64-v8a.sh
@@ -52,7 +52,7 @@ $NDK/toolchains/aarch64-linux-android-4.9/prebuilt/linux-x86_64
 -target
 aarch64-none-linux-android
 -fpic
---sysroot $NDK/platforms/android-21/arch-arm64
+--sysroot $NDK/platforms/$PLATFORMVER/arch-arm64
 -isystem $NDK/sysroot/usr/include
 -isystem $NDK/sysroot/usr/include/aarch64-linux-android
 -D__ANDROID_API__=21
@@ -62,7 +62,7 @@ CFLAGS="`echo $CFLAGS | tr '\n' ' '`"
 
 LDFLAGS="
 -shared
---sysroot $NDK/platforms/android-21/arch-arm64
+--sysroot $NDK/platforms/$PLATFORMVER/arch-arm64
 $NDK/sources/cxx-stl/llvm-libc++/libs/arm64-v8a/libc++_static.a
 $NDK/sources/cxx-stl/llvm-libc++abi/../llvm-libc++/libs/arm64-v8a/libc++abi.a
 $NDK/sources/android/support/../../cxx-stl/llvm-libc++/libs/arm64-v8a/libandroid_support.a

--- a/setCrossEnvironment-armeabi-v7a.sh
+++ b/setCrossEnvironment-armeabi-v7a.sh
@@ -57,7 +57,7 @@ armv7-none-linux-androideabi15
 -mthumb
 -fpic
 -fno-integrated-as
---sysroot $NDK/platforms/android-14/arch-arm
+--sysroot $NDK/platforms/$PLATFORMVER/arch-arm
 -isystem $NDK/sysroot/usr/include
 -isystem $NDK/sysroot/usr/include/arm-linux-androideabi
 -D__ANDROID_API__=15
@@ -67,7 +67,7 @@ CFLAGS="`echo $CFLAGS | tr '\n' ' '`"
 
 LDFLAGS="
 -shared
---sysroot $NDK/platforms/android-14/arch-arm
+--sysroot $NDK/platforms/$PLATFORMVER/arch-arm
 $NDK/sources/cxx-stl/llvm-libc++/libs/armeabi-v7a/libc++_static.a
 $NDK/sources/cxx-stl/llvm-libc++abi/../llvm-libc++/libs/armeabi-v7a/libc++abi.a
 $NDK/sources/android/support/../../cxx-stl/llvm-libc++/libs/armeabi-v7a/libandroid_support.a

--- a/setCrossEnvironment-armeabi.sh
+++ b/setCrossEnvironment-armeabi.sh
@@ -57,7 +57,7 @@ armv5te-none-linux-androideabi14
 -mthumb
 -fpic
 -fno-integrated-as
---sysroot $NDK/platforms/android-14/arch-arm
+--sysroot $NDK/platforms/$PLATFORMVER/arch-arm
 -isystem $NDK/sysroot/usr/include
 -isystem $NDK/sysroot/usr/include/arm-linux-androideabi
 -D__ANDROID_API__=14
@@ -67,7 +67,7 @@ CFLAGS="`echo $CFLAGS | tr '\n' ' '`"
 
 LDFLAGS="
 -shared
---sysroot $NDK/platforms/android-14/arch-arm
+--sysroot $NDK/platforms/$PLATFORMVER/arch-arm
 $NDK/sources/cxx-stl/llvm-libc++/libs/armeabi/libc++_static.a
 $NDK/sources/cxx-stl/llvm-libc++abi/../llvm-libc++/libs/armeabi/libc++abi.a
 $NDK/sources/android/support/../../cxx-stl/llvm-libc++/libs/armeabi/libandroid_support.a

--- a/setCrossEnvironment-x86.sh
+++ b/setCrossEnvironment-x86.sh
@@ -53,7 +53,7 @@ $NDK/toolchains/x86-4.9/prebuilt/linux-x86_64
 i686-none-linux-android
 -fPIC
 -mstackrealign
---sysroot $NDK/platforms/android-14/arch-x86
+--sysroot $NDK/platforms/$PLATFORMVER/arch-x86
 -isystem $NDK/sysroot/usr/include
 -isystem $NDK/sysroot/usr/include/i686-linux-android
 -D__ANDROID_API__=15
@@ -63,7 +63,7 @@ CFLAGS="`echo $CFLAGS | tr '\n' ' '`"
 
 LDFLAGS="
 -shared
---sysroot $NDK/platforms/android-14/arch-x86
+--sysroot $NDK/platforms/$PLATFORMVER/arch-x86
 $NDK/sources/cxx-stl/llvm-libc++/libs/x86/libc++_static.a
 $NDK/sources/cxx-stl/llvm-libc++abi/../llvm-libc++/libs/x86/libc++abi.a
 $NDK/sources/android/support/../../cxx-stl/llvm-libc++/libs/x86/libandroid_support.a

--- a/setCrossEnvironment-x86_64.sh
+++ b/setCrossEnvironment-x86_64.sh
@@ -52,7 +52,7 @@ $NDK/toolchains/x86_64-4.9/prebuilt/linux-x86_64
 -target
 x86_64-none-linux-android
 -fPIC
---sysroot $NDK/platforms/android-21/arch-x86_64
+--sysroot $NDK/platforms/$PLATFORMVER/arch-x86_64
 -isystem $NDK/sysroot/usr/include
 -isystem $NDK/sysroot/usr/include/x86_64-linux-android
 -D__ANDROID_API__=21
@@ -62,7 +62,7 @@ CFLAGS="`echo $CFLAGS | tr '\n' ' '`"
 
 LDFLAGS="
 -shared
---sysroot $NDK/platforms/android-21/arch-x86_64
+--sysroot $NDK/platforms/$PLATFORMVER/arch-x86_64
 $NDK/sources/cxx-stl/llvm-libc++/libs/x86_64/libc++_static.a
 $NDK/sources/cxx-stl/llvm-libc++abi/../llvm-libc++/libs/x86_64/libc++abi.a
 $NDK/sources/android/support/../../cxx-stl/llvm-libc++/libs/x86_64/libandroid_support.a


### PR DESCRIPTION
Even if PLATFORMVER was allowed as a envvar and set with a default,
the value was not used in the paths pointing to the NDK.

NDK r18 removes some of the API levels pointed by default in the
files, so it would never have work for r18. Using PLATFORMVER, one
can specify an API level that exist in r18 (like android-21) and
compile correctly.

This will not work by itself to compile in r18. It needs also #10.